### PR TITLE
Dependency Injection for Mods

### DIFF
--- a/PhoenixPointModLoader/Config/IConfigProvider.cs
+++ b/PhoenixPointModLoader/Config/IConfigProvider.cs
@@ -2,8 +2,8 @@
 {
 	public interface IConfigProvider
 	{
-		T Read<T>(string relativeFilePath);
+		T Read<T>();
 
-		bool Write<T>(T config, string relativeFilePath);
+		bool Write<T>(T config);
 	}
 }

--- a/PhoenixPointModLoader/Config/IConfigProvider.cs
+++ b/PhoenixPointModLoader/Config/IConfigProvider.cs
@@ -1,9 +1,0 @@
-﻿namespace PhoenixPointModLoader.Config
-{
-	public interface IConfigProvider
-	{
-		T Read<T>();
-
-		bool Write<T>(T config);
-	}
-}

--- a/PhoenixPointModLoader/Config/IConfigProvider.cs
+++ b/PhoenixPointModLoader/Config/IConfigProvider.cs
@@ -1,0 +1,9 @@
+﻿namespace PhoenixPointModLoader.Config
+{
+	public interface IConfigProvider
+	{
+		T Read<T>(string relativeFilePath);
+
+		bool Write<T>(T config, string relativeFilePath);
+	}
+}

--- a/PhoenixPointModLoader/Config/IFileConfigProvider.cs
+++ b/PhoenixPointModLoader/Config/IFileConfigProvider.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PhoenixPointModLoader.Config
+{
+	public interface IFileConfigProvider
+	{
+		string RelativeFilePath { get; set; }
+
+		T Read<T>();
+
+		bool Write<T>(T config);
+	}
+}

--- a/PhoenixPointModLoader/Config/JsonConfigProvider.cs
+++ b/PhoenixPointModLoader/Config/JsonConfigProvider.cs
@@ -6,10 +6,17 @@ namespace PhoenixPointModLoader.Config
 {
 	public class JsonConfigProvider : IConfigProvider
 	{
-		public T Read<T>(string relativeFilePath)
+		public string RelativeFilePath { get; }
+
+		public JsonConfigProvider(string relativeFilePath)
 		{
-			string absolutePath = Path.Combine(PhoenixPointModLoader.ModDirectory, Path.GetDirectoryName(relativeFilePath));
-			if (!File.Exists(relativeFilePath))
+			RelativeFilePath = relativeFilePath;
+		}
+
+		public T Read<T>()
+		{
+			string absolutePath = Path.Combine(PhoenixPointModLoader.ModDirectory, Path.GetDirectoryName(RelativeFilePath));
+			if (!File.Exists(RelativeFilePath))
 			{
 				throw new FileNotFoundException($"The config file was not found at path `{absolutePath}`");
 			}
@@ -20,9 +27,9 @@ namespace PhoenixPointModLoader.Config
 			return configObject;
 		}
 
-		public bool Write<T>(T config, string relativeFilePath)
+		public bool Write<T>(T config)
 		{
-			string absolutePath = Path.Combine(PhoenixPointModLoader.ModDirectory, Path.GetDirectoryName(relativeFilePath));
+			string absolutePath = Path.Combine(PhoenixPointModLoader.ModDirectory, Path.GetDirectoryName(RelativeFilePath));
 			string configText = JsonConvert.SerializeObject(config, Formatting.Indented);
 
 			try

--- a/PhoenixPointModLoader/Config/JsonConfigProvider.cs
+++ b/PhoenixPointModLoader/Config/JsonConfigProvider.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.IO;
+using Newtonsoft.Json;
+
+namespace PhoenixPointModLoader.Config
+{
+	public class JsonConfigProvider : IConfigProvider
+	{
+		public T Read<T>(string relativeFilePath)
+		{
+			string absolutePath = Path.Combine(PhoenixPointModLoader.ModDirectory, Path.GetDirectoryName(relativeFilePath));
+			if (!File.Exists(relativeFilePath))
+			{
+				throw new FileNotFoundException($"The config file was not found at path `{absolutePath}`");
+			}
+
+			string configText = File.ReadAllText(absolutePath);
+			T configObject = JsonConvert.DeserializeObject<T>(configText);
+
+			return configObject;
+		}
+
+		public bool Write<T>(T config, string relativeFilePath)
+		{
+			string absolutePath = Path.Combine(PhoenixPointModLoader.ModDirectory, Path.GetDirectoryName(relativeFilePath));
+			string configText = JsonConvert.SerializeObject(config, Formatting.Indented);
+
+			try
+			{
+				File.WriteAllText(absolutePath, configText);
+			}
+			catch (Exception e)
+			{
+				Logger.Log($"Exception occurred while writing to config file `{absolutePath}`.");
+				Logger.Log(e.ToString());
+				return false;
+			}
+
+			return true;
+		}
+	}
+}

--- a/PhoenixPointModLoader/Config/JsonConfigProvider.cs
+++ b/PhoenixPointModLoader/Config/JsonConfigProvider.cs
@@ -4,19 +4,20 @@ using Newtonsoft.Json;
 
 namespace PhoenixPointModLoader.Config
 {
-	public class JsonConfigProvider : IConfigProvider
+	public class JsonConfigProvider : IFileConfigProvider
 	{
-		public string RelativeFilePath { get; }
-
-		public JsonConfigProvider(string relativeFilePath)
-		{
-			RelativeFilePath = relativeFilePath;
-		}
+		public string RelativeFilePath { get; set; }
 
 		public T Read<T>()
 		{
-			string absolutePath = Path.Combine(PhoenixPointModLoader.ModDirectory, Path.GetDirectoryName(RelativeFilePath));
-			if (!File.Exists(RelativeFilePath))
+			if (string.IsNullOrEmpty(RelativeFilePath))
+			{
+				throw new InvalidOperationException("A relative file path to the `Mods` folder must be provided. " +
+					"Try setting the `RelativeFilePath` property first.");
+			}
+
+			string absolutePath = Path.Combine(PhoenixPointModLoader.ModDirectory, RelativeFilePath);
+			if (!File.Exists(absolutePath))
 			{
 				throw new FileNotFoundException($"The config file was not found at path `{absolutePath}`");
 			}
@@ -29,7 +30,13 @@ namespace PhoenixPointModLoader.Config
 
 		public bool Write<T>(T config)
 		{
-			string absolutePath = Path.Combine(PhoenixPointModLoader.ModDirectory, Path.GetDirectoryName(RelativeFilePath));
+			if (string.IsNullOrEmpty(RelativeFilePath))
+			{
+				throw new InvalidOperationException("A relative file path to the `Mods` folder must be provided. " +
+					"Try setting the `RelativeFilePath` property first.");
+			}
+
+			string absolutePath = Path.Combine(PhoenixPointModLoader.ModDirectory, RelativeFilePath);
 			string configText = JsonConvert.SerializeObject(config, Formatting.Indented);
 
 			try

--- a/PhoenixPointModLoader/Infrastructure/CompositionRoot.cs
+++ b/PhoenixPointModLoader/Infrastructure/CompositionRoot.cs
@@ -1,0 +1,19 @@
+﻿using PhoenixPointModLoader.Config;
+using SimpleInjector;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PhoenixPointModLoader.Infrastructure
+{
+	public static class CompositionRoot
+	{
+		public static void ConfigureContainer(Container container)
+		{
+			container.Register<IFileConfigProvider, JsonConfigProvider>();
+			container.Verify();
+		}
+	}
+}

--- a/PhoenixPointModLoader/Logger.cs
+++ b/PhoenixPointModLoader/Logger.cs
@@ -1,11 +1,22 @@
 ﻿using System;
 using System.IO;
+using System.Reflection;
 
 namespace PhoenixPointModLoader
 {
     internal static class Logger
     {
         internal static string LogPath { get; set; }
+
+        internal static void InitializeLogging(string logFile)
+        {
+            Logger.LogPath = logFile;
+            Version PPMLVersion = Assembly.GetExecutingAssembly().GetName().Version;
+            using (var logWriter = File.CreateText(LogPath))
+            {
+                logWriter.WriteLine($"PPModLoader -- PPML v{PPMLVersion} -- {DateTime.Now}");
+            }
+        }
 
         internal static void Log(string message, params object[] formatObjects)
         {

--- a/PhoenixPointModLoader/Mods/EnableConsoleMod.cs
+++ b/PhoenixPointModLoader/Mods/EnableConsoleMod.cs
@@ -1,14 +1,47 @@
 ﻿using Base.Utils.GameConsole;
+using PhoenixPointModLoader.Config;
+using System.IO;
 
 namespace PhoenixPointModLoader.Mods
 {
 	public class EnableConsoleMod : IPhoenixPointMod
 	{
+		private EnableConsoleConfig consoleAccessConfig;
+		private IFileConfigProvider configProvider;
+
 		public ModLoadPriority Priority => ModLoadPriority.Normal;
+
+		public EnableConsoleMod(IFileConfigProvider config)
+		{
+			config.RelativeFilePath = "EnableConsoleAccess.json";
+			configProvider = config;
+		}
 
 		public void Initialize()
 		{
-			GameConsoleWindow.DisableConsoleAccess = false;
+			try
+			{
+				consoleAccessConfig = configProvider.Read<EnableConsoleConfig>();
+			}
+			catch (FileNotFoundException)
+			{
+				consoleAccessConfig = new EnableConsoleConfig() { EnableConsoleAccess = true };
+				configProvider.Write(consoleAccessConfig);
+			}
+			finally
+			{
+				SetConsoleAccess(consoleAccessConfig.EnableConsoleAccess);
+			}
+		}
+
+		private void SetConsoleAccess(bool enabled)
+		{
+			GameConsoleWindow.DisableConsoleAccess = !enabled;
+		}
+
+		private class EnableConsoleConfig
+		{
+			public bool EnableConsoleAccess { get; set; } = true;
 		}
 	}
 }

--- a/PhoenixPointModLoader/PhoenixPointModLoader.cs
+++ b/PhoenixPointModLoader/PhoenixPointModLoader.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Reflection;
 using Harmony;
 using PhoenixPointModLoader.Mods;
-using static PhoenixPointModLoader.Logger;
 
 namespace PhoenixPointModLoader
 {
@@ -20,43 +19,26 @@ namespace PhoenixPointModLoader
 
 		public static string ModDirectory { get; private set; }
 
-	
-
 		public static void Initialize()
 		{
 			string manifestDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)
-				?? throw new InvalidOperationException("Manifest path is invalid.");
+				?? throw new InvalidOperationException("Could not determine operating directory. Is your folder structure correct? " +
+				"Try verifying game files in the Epic Games Launcher, if you're using it.");
 
-
-			// this should be (wherever Phoenix Point is Installed)\PhoenixPoint\PhoenixPointWin64_Data\Managed
-			ModDirectory = Path.GetFullPath(
-				Path.Combine(manifestDirectory, Path.Combine(@"..\..\Mods")));
-
-			LogPath = Path.Combine(ModDirectory, "PPModLoader.log");
-
-			Version PPMLVersion = Assembly.GetExecutingAssembly().GetName().Version;
+			ModDirectory = Path.GetFullPath(Path.Combine(manifestDirectory, Path.Combine(@"..\..\Mods")));
 
 			if (!Directory.Exists(ModDirectory))
 				Directory.CreateDirectory(ModDirectory);
 
-			// create log file, overwriting if it's already there
-			using (var logWriter = File.CreateText(LogPath))
-			{
-				logWriter.WriteLine($"PPModLoader -- PPML v{PPMLVersion} -- {DateTime.Now}");
-			}
+			Logger.InitializeLogging(Path.Combine(ModDirectory, "PPModLoader.log"));
 
-			// ReSharper disable once UnusedVariable
-			var harmony = HarmonyInstance.Create("io.github.realitymachina.PPModLoader");
+			IList<IPhoenixPointMod> allMods = RetrieveAllMods();
+			InitializeMods(allMods);
+		}
 
-			// get all dll paths
+		private static IList<IPhoenixPointMod> RetrieveAllMods()
+		{
 			List<string> dllPaths = Directory.GetFiles(ModDirectory, "*.dll", SearchOption.AllDirectories).ToList();
-
-			if (!dllPaths.Any())
-			{
-				Log(@"No .DLLs loaded. DLLs must be placed in the root of the folder \PhoenixPoint\Mods\.");
-				return;
-			}
-
 			List<IPhoenixPointMod> allMods = new List<IPhoenixPointMod>();
 			IncludeDefaultMods(allMods);
 			foreach (var dllPath in dllPaths)
@@ -64,41 +46,37 @@ namespace PhoenixPointModLoader
 				if (!IGNORE_FILE_NAMES.Contains(Path.GetFileName(dllPath)))
 					allMods.AddRange(LoadDll(dllPath));
 			}
-
-			InitializeMods(allMods);	
+			return allMods;
 		}
 
-		private static void IncludeDefaultMods(List<IPhoenixPointMod> allMods)
+		private static void IncludeDefaultMods(IList<IPhoenixPointMod> allMods)
 		{
-			allMods.AddRange(new IPhoenixPointMod[]
-			{
-				new EnableConsoleMod(),
-				new LoadConsoleCommandsFromAllAssembliesMod()
-			});
+			allMods.Add(new EnableConsoleMod());
+			allMods.Add(new LoadConsoleCommandsFromAllAssembliesMod());
 		}
 
-		private static void InitializeMods(List<IPhoenixPointMod> allMods)
+		private static void InitializeMods(IList<IPhoenixPointMod> allMods)
 		{
 			var prioritizedModList = allMods.ToLookup(x => x.Priority);
 			ModLoadPriority[] loadOrder = new[] { ModLoadPriority.High, ModLoadPriority.Normal, ModLoadPriority.Low };
 			foreach (ModLoadPriority priority in loadOrder)
 			{
-				Log("Attempting to initialize `{0}` priority mods.", priority.ToString());
+				Logger.Log("Attempting to initialize `{0}` priority mods.", priority.ToString());
 				foreach (var mod in prioritizedModList[priority])
 				{
 					try
 					{
 						mod.Initialize();
-						Log("Mod class `{0}` from DLL `{1}` was successfully initialized.",
+						Logger.Log("Mod class `{0}` from DLL `{1}` was successfully initialized.",
 							mod.GetType().Name,
 							Path.GetFileName(mod.GetType().Assembly.Location));
 					}
 					catch (Exception e)
 					{
-						Log("Mod class `{0}` from DLL `{1}` failed to initialize.",
+						Logger.Log("Mod class `{0}` from DLL `{1}` failed to initialize.",
 							mod.GetType().Name,
 							Path.GetFileName(mod.GetType().Assembly.Location));
-						Log(e.ToString());
+						Logger.Log(e.ToString());
 					}
 				}
 			}
@@ -114,7 +92,7 @@ namespace PhoenixPointModLoader
 
 			if (!modClasses.Any())
 			{
-				Log("No mod classes found in DLL: {0}", Path.GetFileName(path));
+				Logger.Log("No mod classes found in DLL: {0}", Path.GetFileName(path));
 				return new List<IPhoenixPointMod>();
 			}
 
@@ -128,14 +106,15 @@ namespace PhoenixPointModLoader
 				}
 				catch (Exception e)
 				{
-					Log("Error has occurred when instantiating mod class`{0}` in DLL `{1}`.", modClass.Name, Path.GetFileName(path));
-					Log(e.ToString());
+					Logger.Log("Error has occurred when instantiating mod class`{0}` in DLL `{1}`.", modClass.Name, Path.GetFileName(path));
+					Logger.Log(e.ToString());
 					continue;
 				}
 
 				if (modInstance == null)
 				{
-					Log("Instantiated mod class `{0}` from DLL `{1}` was null for unknown reason.", modClass.Name, Path.GetFileName(path));
+					Logger.Log("Instantiated mod class `{0}` from DLL `{1}` was null for unknown reason. " +
+						"Please ensure you have a default constructor defined for your type.", modClass.Name, Path.GetFileName(path));
 				}
 
 				modInstances.Add(modInstance);

--- a/PhoenixPointModLoader/PhoenixPointModLoader.csproj
+++ b/PhoenixPointModLoader/PhoenixPointModLoader.csproj
@@ -53,8 +53,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Config\IConfigProvider.cs" />
+    <Compile Include="Config\IFileConfigProvider.cs" />
     <Compile Include="Config\JsonConfigProvider.cs" />
+    <Compile Include="Infrastructure\CompositionRoot.cs" />
     <Compile Include="Logger.cs" />
     <Compile Include="Mods\EnableConsoleMod.cs" />
     <Compile Include="Mods\EnableOptionsUIEditingPatch.cs" />
@@ -71,6 +72,10 @@
     <PackageReference Include="Newtonsoft.Json">
       <Version>12.0.3</Version>
     </PackageReference>
+    <PackageReference Include="SimpleInjector">
+      <Version>4.9.0</Version>
+    </PackageReference>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/PhoenixPointModLoader/PhoenixPointModLoader.csproj
+++ b/PhoenixPointModLoader/PhoenixPointModLoader.csproj
@@ -53,6 +53,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Config\IConfigProvider.cs" />
+    <Compile Include="Config\JsonConfigProvider.cs" />
     <Compile Include="Logger.cs" />
     <Compile Include="Mods\EnableConsoleMod.cs" />
     <Compile Include="Mods\EnableOptionsUIEditingPatch.cs" />
@@ -65,6 +67,9 @@
   <ItemGroup>
     <PackageReference Include="Lib.Harmony">
       <Version>1.2.0.1</Version>
+    </PackageReference>
+    <PackageReference Include="Newtonsoft.Json">
+      <Version>12.0.3</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ Once all `IPhoenixPointMod` objects have been instantiated and sorted by `ModLoa
 
 # Development To-Do List
 
-- [ ] Allow for more robust mod constructors and inject dependencies. (Use an IoC container for this?)
+- [x] Allow for more robust mod constructors and inject dependencies. (Use an IoC container for this?)
 - [ ] More robust mod loading settings. (e.g. disable certain mods)
 - [ ] More robust mod metadata. (e.g. game version compatibility, dependencies, etc.)
 - [ ] Incorporate functionality of PPDefModifier with taketwo's blessing.
 - [ ] Allow for asset replacement.
-- [ ] Provide config file API for mods.
+- [x] Provide config file API for mods.
 - [ ] Provide game behavior hooks, if possible.
 - [ ] Provide cache of PP game objects (items, weapons, armor, etc.)
 - [ ] Provide API for custom UI (such as menus, popups, etc.)

--- a/README.md
+++ b/README.md
@@ -31,16 +31,14 @@ The mod loader will recursively search the `Mods` directory in order to obtain a
 
 Once all `IPhoenixPointMod` objects have been instantiated and sorted by `ModLoadPriority` in order of `High`, `Normal`, `Low`; the mod loader will execute the `Initialize()` method on each instance.
 
-**NOTE:** Due to the fact that reflection is being used to instantiate mods, please ensure that your types have a default or parameterless constructor defined! Not doing so runs the risk of your mods not being usable.
-
 # Development To-Do List
 
-- [ ] Allow for more robust mod constructors and inject dependencies. (Use an IoC container for this?)
+- [x] Allow for more robust mod constructors and inject dependencies. (Use an IoC container for this?)
 - [ ] More robust mod loading settings. (e.g. disable certain mods)
 - [ ] More robust mod metadata. (e.g. game version compatibility, dependencies, etc.)
 - [ ] Incorporate functionality of PPDefModifier with taketwo's blessing.
 - [ ] Allow for asset replacement.
-- [ ] Provide config file API for mods.
+- [x] Provide config file API for mods.
 - [ ] Provide game behavior hooks, if possible.
 - [ ] Provide cache of PP game objects (items, weapons, armor, etc.)
 - [ ] Provide API for custom UI (such as menus, popups, etc.)


### PR DESCRIPTION
SimpleInjector is now used to provide DI for mods. Mods may request services provided by PPML by placing them as constructor parameters. PPML will attempt to resolve the dependencies and provide them to the mod during construction.

Recommended best practice is to store the injected services and only make use of them in the `Initialize()` function so as to prevent unintended behavior when constructing mods.

See the `EnableConsoleAccess` mod for an example.

Currently only one service is made available to mods, the `IFileConfigProvider`. This is implemented by the `JsonFileConfigProvider` as an easy way to read and dump configuration objects. JSON isn't necessarily the format I'm settling on permanently as it's not the most user friendly. However, it's developer-friendly and I'm trying to make some progress.